### PR TITLE
Enforcing limit of description when it's not rich text

### DIFF
--- a/app/v2/controllers/contribution/page.js
+++ b/app/v2/controllers/contribution/page.js
@@ -1085,7 +1085,7 @@
       let allowChangeStatusConf = $scope.campaignConfigs['appcivist.campaign.contribution.status.change-enabled'];
       let showInstructionsConf = $scope.campaignConfigs['appcivist.campaign.components.display-instructions'];
       let hasKeywordsLimit = $scope.campaignConfigs['appcivist.campaign.keywords.limit'];
-      let hasDescriptionLimit = $.scope.campaignConfigs['appcivist.campaign.contribution-summary-word-limit'];
+      let hasDescriptionLimit = $scope.campaignConfigs['appcivist.campaign.contribution-summary-word-limit'];
 
       $scope.showContributingIdeas  = showContributingIdeasConf ? showContributingIdeasConf.toLowerCase()  === 'false' ? false : true : true;
       $scope.showHistory = showHistoryConf ? showHistoryConf.toLowerCase()  === 'false' ? false : true : true;
@@ -1104,7 +1104,7 @@
       $scope.showCustomFieldsTitle = showCustomFieldsTitleConf ? showCustomFieldsTitleConf.toLowerCase() === 'false' ? false : true : true;
       $scope.showCustomFieldsHeader = showCustomFieldsHeaderConf ? showCustomFieldsHeaderConf.toLowerCase() === 'false' ? false : true : true;
       $scope.showMediaCarousel = showMediaCarouselConf ? showMediaCarouselConf.toLowerCase() === 'false' ? false : true : true;
-      $scope.showDescriptionRichTextEdit = showDescriptionRichTextEditConf ? showDescriptionRichTextEditConf.toLowerCase() === 'false' ? false : true : true;
+      $scope.showDescriptionRichTextEdit = showDescriptionRichTextEditConf ? showDescriptionRichTextEditConf.toLowerCase() === 'false' ? false : true : false;
       $scope.allowChangeStatus = allowChangeStatusConf ? allowChangeStatusConf.toLowerCase() === 'false' ? false : true : true;
       $scope.showInstructions = showInstructionsConf ? showInstructionsConf.toLowerCase() === 'false' ? false : true : true;
       $scope.keywordsLimit = hasKeywordsLimit ? hasKeywordsLimit : false;

--- a/app/v2/controllers/contribution/page.js
+++ b/app/v2/controllers/contribution/page.js
@@ -81,6 +81,7 @@
     $scope.getNonMemberAuthorsHeadless = getNonMemberAuthorsHeadless.bind($scope);
     $scope.filterCreatorFromAuthors = filterCreatorFromAuthors.bind($scope);
     $scope.isCurrentAuthor = isCurrentAuthor.bind($scope);
+    $scope.enforceLimit = enforceLimit.bind($scope);
 
     activate();
 
@@ -1084,6 +1085,7 @@
       let allowChangeStatusConf = $scope.campaignConfigs['appcivist.campaign.contribution.status.change-enabled'];
       let showInstructionsConf = $scope.campaignConfigs['appcivist.campaign.components.display-instructions'];
       let hasKeywordsLimit = $scope.campaignConfigs['appcivist.campaign.keywords.limit'];
+      let hasDescriptionLimit = $.scope.campaignConfigs['appcivist.campaign.contribution-summary-word-limit'];
 
       $scope.showContributingIdeas  = showContributingIdeasConf ? showContributingIdeasConf.toLowerCase()  === 'false' ? false : true : true;
       $scope.showHistory = showHistoryConf ? showHistoryConf.toLowerCase()  === 'false' ? false : true : true;
@@ -1106,6 +1108,7 @@
       $scope.allowChangeStatus = allowChangeStatusConf ? allowChangeStatusConf.toLowerCase() === 'false' ? false : true : true;
       $scope.showInstructions = showInstructionsConf ? showInstructionsConf.toLowerCase() === 'false' ? false : true : true;
       $scope.keywordsLimit = hasKeywordsLimit ? hasKeywordsLimit : false;
+      $scope.descriptionLimit = hasDescriptionLimit ? parseInt(hasDescriptionLimit) : false;
 
       if ($scope.keywordsLimit) {
         if ($scope.proposal.themes.filter(t => t.type == 'EMERGENT').length == $scope.keywordsLimit) {
@@ -1953,29 +1956,44 @@
     }
 
     function saveDescription() {
-      let vm = this;
-      let payload = _.cloneDeep($scope.proposal);
-      delete payload.lastUpdate;
-      delete payload.attachments;
-      payload.status = payload.status.toUpperCase();
-      let rsp = Contributions.contribution($scope.assemblyID, $scope.proposal.contributionId).update(payload).$promise;
+      if (!this.showDescriptionRichTextEdit && this.descriptionLimit && this.proposal.text > this.descriptionLimit) {
+        $translate('Description limit', { limit: this.descriptionLimit })
+          .then(
+            msg => {
+              Notify.show(msg, 'error');
+            });
+      } else {
+        let vm = this;
+        let payload = _.cloneDeep($scope.proposal);
+        delete payload.lastUpdate;
+        delete payload.attachments;
+        payload.status = payload.status.toUpperCase();
+        let rsp = Contributions.contribution($scope.assemblyID, $scope.proposal.contributionId).update(payload).$promise;
 
-      rsp.then(
-        data => {
-          $translate('Changed was saved')
-            .then(
-              msg => {
-                Notify.show(msg, 'success');
-              });
-          vm.isDescriptionEdit = false;
-          $("#descriptionEditToggle").addClass('fa-edit');
-          $("#descriptionEditToggle").removeClass('fa-times-circle');
-        },
-        error => {
-          Notify.show(error.data ? error.data.statusMessage ? error.data.statusMessage : '' : '', 'error');
-          vm.isDescriptionEdit = true;
-        }
-      );
+        rsp.then(
+          data => {
+            $translate('Changed was saved')
+              .then(
+                msg => {
+                  Notify.show(msg, 'success');
+                });
+            vm.isDescriptionEdit = false;
+            $("#descriptionEditToggle").addClass('fa-edit');
+            $("#descriptionEditToggle").removeClass('fa-times-circle');
+          },
+          error => {
+            Notify.show(error.data ? error.data.statusMessage ? error.data.statusMessage : '' : '', 'error');
+            vm.isDescriptionEdit = true;
+          }
+        );
+      }
+    }
+
+    function enforceLimit() {
+      if (this.descriptionLimit) {
+        if (this.proposal.text.length > this.descriptionLimit)
+          this.proposal.text = this.proposal.text.substring(0, this.descriptionLimit);
+      }
     }
 
     function saveTitle() {

--- a/app/v2/partials/contribution/page.html
+++ b/app/v2/partials/contribution/page.html
@@ -316,7 +316,7 @@
             <textarea ng-if="showDescriptionRichTextEdit" ui-tinymce="tinymceOptions" ng-model="proposal.text"
                       id="add_proposal__description" name="text" rows="8" cols="48"
                       placeholder="{{'Description' | translate}}"></textarea>
-            <textarea ng-if="!showDescriptionRichTextEdit"  ng-model="proposal.text"
+            <textarea ng-if="!showDescriptionRichTextEdit"  ng-model="proposal.text" ng-change="enforceLimit()"
                       id="add_proposal__description" name="text" rows="8" cols="48"
                       placeholder="{{'Description' | translate}}"></textarea>
             <button class="btn btn-default btn-join" ng-click="descriptionToggleEdit()">{{'Cancel' | translate}}</button>

--- a/assets/i18n/locale-de-DE.json
+++ b/assets/i18n/locale-de-DE.json
@@ -1412,5 +1412,6 @@
   "Registered users": "Registered users",
   "Not yet registered": "Not yet registered",
   "Shared proposals": "Shared with me",
-  "Shared ideas": "Shared with me"
+  "Shared ideas": "Shared with me",
+  "Description limit": "Description can't be longer than {{limit}} characters"
 }

--- a/assets/i18n/locale-en-US.json
+++ b/assets/i18n/locale-en-US.json
@@ -1418,5 +1418,6 @@
   "Registered users": "Registered users",
   "Not yet registered": "Not yet registered",
   "Shared proposals": "Shared with me",
-  "Shared ideas": "Shared with me"
+  "Shared ideas": "Shared with me",
+  "Description limit": "Description can't be longer than {{limit}} characters"
 }

--- a/assets/i18n/locale-es-ES.json
+++ b/assets/i18n/locale-es-ES.json
@@ -1418,5 +1418,6 @@
   "Registered users": "Uusarios registrados",
   "Not yet registered": "Aún no se han registrado",
   "Shared proposals": "Compartidas conmigo",
-  "Shared ideas": "Compartidas conmigo"
+  "Shared ideas": "Compartidas conmigo",
+  "Description limit": "La descripción no debe tener más de {{limit}} caracteres"
 }

--- a/assets/i18n/locale-es-PY.json
+++ b/assets/i18n/locale-es-PY.json
@@ -1418,5 +1418,6 @@
   "Registered users": "Usuarios registrados",
   "Not yet registered": "Aún no se han registrado",
   "Shared proposals": "Compartidas conmigo",
-  "Shared ideas": "Compartidas conmigo"
+  "Shared ideas": "Compartidas conmigo",
+  "Description limit": "La descripción no debe tener más de {{limit}} caracteres"
 }

--- a/assets/i18n/locale-fr-CA.json
+++ b/assets/i18n/locale-fr-CA.json
@@ -1418,5 +1418,6 @@
   "Registered users": "Registered users",
   "Not yet registered": "Not yet registered",
   "Shared proposals": "Shared with me",
-  "Shared ideas": "Shared with me"
+  "Shared ideas": "Shared with me",
+  "Description limit": "Description can't be longer than {{limit}} characters"
 }

--- a/assets/i18n/locale-fr-FR.json
+++ b/assets/i18n/locale-fr-FR.json
@@ -1418,5 +1418,6 @@
   "Registered users": "Registered users",
   "Not yet registered": "Not yet registered",
   "Shared proposals": "Shared with me",
-  "Shared ideas": "Shared with me"
+  "Shared ideas": "Shared with me",
+  "Description limit": "Description can't be longer than {{limit}} characters"
 }

--- a/assets/i18n/locale-it-IT.json
+++ b/assets/i18n/locale-it-IT.json
@@ -1416,5 +1416,6 @@
   "Registered users": "Registered users",
   "Not yet registered": "Not yet registered",
   "Shared proposals": "Shared with me",
-  "Shared ideas": "Shared with me"
+  "Shared ideas": "Shared with me",
+  "Description limit": "Description can't be longer than {{limit}} characters"
 }

--- a/assets/i18n/locale-pt-BR.json
+++ b/assets/i18n/locale-pt-BR.json
@@ -1418,5 +1418,6 @@
   "Registered users": "Registrado no site",
   "Not yet registered": "Ainda não registrado",
   "Shared proposals": "Compartilhadas comigo",
-  "Shared ideas": "Compartilhadas comigo"
+  "Shared ideas": "Compartilhadas comigo",
+  "Description limit": "Resumo não pode ter mais que {{limit}} caracteres"
 }


### PR DESCRIPTION
When using rich text we need to avoid counting the HTML tags and it needs a little more work, so the limit is only enforced for plain text summaries for now.