### PR TITLE
Fixed captcha errors, double checked space IDs

### DIFF
--- a/app/v2/partials/directives/proposals-ideas-searchbox.html
+++ b/app/v2/partials/directives/proposals-ideas-searchbox.html
@@ -35,10 +35,10 @@
       <li class="search_mode__full_text" ng-class="{active: (filters.mode === 'myIdeas')}" ng-if="(campaignConfig['appcivist.campaign.filter.mine']!=='HIDE') && !isAnonymous && (currentComponent.type === 'IDEAS' || campaignContributionTypes.includes('IDEA'))">
         <a ng-click="searchMode('myIdeas', $event)">{{ 'My Ideas' | translate | titlecase}}</a>
       </li>
-      <li class="search_mode__full_text" ng-class="{active: (filters.mode === 'draftProposals')}" ng-if="(campaignConfig['appcivist.campaign.filter.draft']!=='HIDE') && !isAnonymous && currentComponent.type !== 'IDEAS' && isCoordinator">
+      <li class="search_mode__full_text" ng-class="{active: (filters.mode === 'draftProposals')}" ng-if="(campaignConfig['appcivist.campaign.filter.draft']!=='HIDE' || campaignConfig['appcivist.working-group.hide-others-private-drafts'] !== 'TRUE') && !isAnonymous && currentComponent.type !== 'IDEAS' && isCoordinator">
         <a ng-click="searchMode('draftProposals', $event)">{{'Draft Proposals' | translate | titlecase}}</a>
       </li>
-      <li class="search_mode__full_text" ng-class="{active: (filters.mode === 'draftIdeas')}" ng-if="(campaignConfig['appcivist.campaign.filter.draft']!=='HIDE') && !isAnonymous && (currentComponent.type === 'IDEAS' || campaignContributionTypes.includes('IDEA')) && isCoordinator">
+      <li class="search_mode__full_text" ng-class="{active: (filters.mode === 'draftIdeas')}" ng-if="(campaignConfig['appcivist.campaign.filter.draft']!=='HIDE' || campaignConfig['appcivist.working-group.hide-others-private-drafts'] !== 'TRUE') && !isAnonymous && (currentComponent.type === 'IDEAS' || campaignContributionTypes.includes('IDEA')) && isCoordinator">
         <a ng-click="searchMode('draftIdeas', $event)">{{ 'Draft Ideas' | translate | titlecase}}</a>
       </li>
       <li class="search_mode__full_text" ng-class="{active: (filters.mode === 'sharedProposals')}" ng-if="(campaignConfig['appcivist.campaign.filter.shared']!=='HIDE') && !isAnonymous && currentComponent.type !== 'IDEAS'">

--- a/bower.json
+++ b/bower.json
@@ -39,7 +39,7 @@
     "lodash": "~4.16.4",
     "angular-inview": "^2.1.0",
     "ng-notify": "^0.8.0",
-    "angular-recaptcha": "^3.2.1",
+    "angular-recaptcha": "^4.1.5",
     "angularUtils-pagination": "angular-utils-pagination#^0.11.1",
     "github-fork-ribbon-css": "^0.2.0",
     "angularjs-slider": "^6.0.0",


### PR DESCRIPTION
Apparently this was an error on the `angular-recaptcha` library, as reported in VividCortex/angular-recaptcha#224. I've updated the `bower.json` so it brings the latest version of the library which should fix the issue.

Also, I've checked if the correct space IDs were in use.